### PR TITLE
PyPI regex fix

### DIFF
--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Verify Package Version vs Tag Version
         run: |
-          PKG_VER="$(grep -oP 'version = \"\K[^\"]+' pyproject.toml)"
+          PKG_VER="$(grep -oP '^version = \"\K[^\"]+' pyproject.toml)"
           TAG_VER="${GITHUB_REF##*/}"
           echo "Package version is $PKG_VER" >&2
           echo "Tag version is $TAG_VER" >&2


### PR DESCRIPTION
Fix for PyPI release. It was failing because tag and package versions were not the same, due to a bug in the package version regex.